### PR TITLE
Dev/input control

### DIFF
--- a/AnagramGenerator/AnagramGenerator/Views/GenerationView.swift
+++ b/AnagramGenerator/AnagramGenerator/Views/GenerationView.swift
@@ -18,7 +18,15 @@ struct GenerationView: View {
     @State private var name: String = ""
     @State private var selectedDate = Date()
     
-    let maxNameLen: Int = 9
+    // 1~12 숫자를 월 이름으로 변환하는 딕셔너리
+    let monthDic: [Int: String] = [
+        1: "jan", 2: "feb", 3: "mar", 4: "apr",
+        5: "may", 6: "jun", 7: "jul", 8: "aug",
+        9: "sep", 10: "oct", 11: "nov", 12: "dec"
+    ]
+    
+    let maxInputLen: Int = 9
+    let monthLen: Int = 3
     
     var body: some View {
         NavigationView {
@@ -26,6 +34,7 @@ struct GenerationView: View {
                 Section(header: Text("Keyword")) {
                     TextField("Enter your keyword", text: $keyword)
                 }
+                
                 Section(header: Text("Private info")) {
                     TextField("Enter your name", text: $name)
                         .onChange(of: name) {
@@ -34,15 +43,27 @@ struct GenerationView: View {
                     DatePicker("Birthday", selection: $selectedDate, displayedComponents: .date)
                         .foregroundStyle(.secondary)
                 }
+                
                 Button {
-                    if keyword != "" && name != "" {
+                    if name != "" {
                         anagrams.removeAll()
                         anagrams = generator.generateAnagrams(name, anagrams)
+                        
+                        if name.count + monthLen <= maxInputLen {
+                            let calendar: Calendar = .current
+                            let component = calendar.dateComponents([.month], from: selectedDate)
+                            
+                            if let monthNumber = component.month { // optional binding으로 month를 안전하게 언래핑
+                                let monthName = monthDic[monthNumber] ?? "" // nil인 경우 빈 문자열 사용
+                                let withMonth = name + monthName
+                                anagrams = generator.generateAnagrams(withMonth, anagrams)
+                            }
+                        }
                     }
                 } label: {
                     Text("Generate Anagrams")
                 }
-                .disabled(name.count > maxNameLen)
+                .disabled(name.count > maxInputLen)
                 
                 Section(header: Text("Result anagrams")) {
                     List {

--- a/AnagramGenerator/AnagramGenerator/Views/GenerationView.swift
+++ b/AnagramGenerator/AnagramGenerator/Views/GenerationView.swift
@@ -55,8 +55,8 @@ struct GenerationView: View {
                             
                             if let monthNumber = component.month { // optional binding으로 month를 안전하게 언래핑
                                 let monthName = monthDic[monthNumber] ?? "" // nil인 경우 빈 문자열 사용
-                                let withMonth = name + monthName
-                                anagrams = generator.generateAnagrams(withMonth, anagrams)
+                                let nameWithMonth = name + monthName
+                                anagrams = generator.generateAnagrams(nameWithMonth, anagrams)
                             }
                         }
                     }

--- a/AnagramGenerator/AnagramGenerator/Views/GenerationView.swift
+++ b/AnagramGenerator/AnagramGenerator/Views/GenerationView.swift
@@ -8,12 +8,17 @@
 import SwiftUI
 
 struct GenerationView: View {
+    // AnagramGenerator는 9개의 문자까지만 애너그램을 생성해야 함
+    // 문자 10개가 넘는 문자열에 대해 애너그램 생성 시, 순열을 계산하는 시간이 매우 길기 때문
+    // 순열을 생성하는 알고리즘은 O(n!)의 시간 복잡도를 보유
     @State private var generator = Generator()
     
     @State private var anagrams: [String] = [""]
     @State private var keyword: String = ""
     @State private var name: String = ""
     @State private var selectedDate = Date()
+    
+    let maxNameLen: Int = 9
     
     var body: some View {
         NavigationView {
@@ -24,7 +29,7 @@ struct GenerationView: View {
                 Section(header: Text("Private info")) {
                     TextField("Enter your name", text: $name)
                         .onChange(of: name) {
-                            name = name.lowercased()  // 입력값을 소문자로 변환
+                            name = name.lowercased() // 입력값을 소문자로 변환
                         }
                     DatePicker("Birthday", selection: $selectedDate, displayedComponents: .date)
                         .foregroundStyle(.secondary)
@@ -37,6 +42,7 @@ struct GenerationView: View {
                 } label: {
                     Text("Generate Anagrams")
                 }
+                .disabled(name.count > maxNameLen)
                 
                 Section(header: Text("Result anagrams")) {
                     List {


### PR DESCRIPTION
[dev] 생월을 Anagram에 활용하도록 구현 및 사용자 입력 통제

- 사용자의 이름 입력을 길이 9로 제한
- 생월을 선택하여 Anagram 생성에 활용하도록 구현
- 이름과 생월을 모두 포함하는 문자열의 이름 변경